### PR TITLE
食事記録エクスポートAPIを追加

### DIFF
--- a/app/controllers/api/v1/food_logs_controller.rb
+++ b/app/controllers/api/v1/food_logs_controller.rb
@@ -49,4 +49,13 @@ class Api::V1::FoodLogsController < ApplicationController
     end
     current_user.food_logs.destroy(params[:id])
   end
+
+  def export
+    current_user = current_api_v1_user
+    if !current_user
+      raise "You need to sign in or sign up before continuing."
+    end
+    food_logs = FoodLog.where(meal_date_time: Time.parse(params[:from])..Time.parse(params[:to]))
+    render json: food_logs, meta: { total: food_logs.length }, each_serializer: ExportFoodLogSerializer
+  end
 end

--- a/app/serializers/export_food_log_serializer.rb
+++ b/app/serializers/export_food_log_serializer.rb
@@ -1,0 +1,3 @@
+class ExportFoodLogSerializer < ActiveModel::Serializer
+  attributes :id, :name, :calorie, :amount, :recipe_id, :meal_date_time, :user_id
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,8 @@ Rails.application.routes.draw do
       get '/recipe_ranking', to: 'recipes#ranking'
 
       resources :food_logs, only: %i[index create destroy]
+      get '/food_logs/export', to: 'food_logs#export'
+
       resources :food_log_templates, only: %i[index destroy]
 
       post '/favorites', to: 'favorites#create'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,7 +15,10 @@ set -e
 sudo service nginx start
 
 # /smart-kitchen-api/tmp/sockets/puma.sockを出力させるためにこちらのコマンドを使用する
-rm -f tmp/pids/server.pid && bundle exec puma -C config/puma.rb
+# rm -f tmp/pids/server.pid && bundle exec puma -C config/puma.rb
+
+# ターミナルにログを出力させたいのでrails s でrailsサーバーを起動する
+rm -f tmp/pids/server.pid && bundle exec rails s -p 3000 -b '0.0.0.0'
 
 # Dockerfile内のCMDを実行する
 # exec "$@"


### PR DESCRIPTION
・ターミナルをアタッチしたときにサーバーログを出力させるため、railsサーバーをpumaコマンド起動していたのをrails sコマンドで起動するように変更
・食事記録エクスポートAPIを追加